### PR TITLE
Fix nginx syntax to disable error logs

### DIFF
--- a/ingredients/general/no-logs.conf
+++ b/ingredients/general/no-logs.conf
@@ -1,3 +1,3 @@
     log_not_found off;
-    access_log off;
-    error_log off;
+    access_log /dev/null;
+    error_log /dev/null;


### PR DESCRIPTION
Setting `error_log off` will create a file named `off` in the directory where nginx is running.

See:
https://www.wpoven.com/tutorial/how-to-disable-nginx-logs-on-your-server/
http://nginx.org/en/docs/ngx_core_module.html#error_log